### PR TITLE
Adding check for select input to grab the activeElement of the select…

### DIFF
--- a/build/latest/addons/ux-datagrid-infiniteScroll.js
+++ b/build/latest/addons/ux-datagrid-infiniteScroll.js
@@ -60,9 +60,14 @@ angular.module("ux").factory("infiniteScroll", function() {
                 // get the row id of the focused element.
                 var rowIndex = inst.getRowIndexFromElement(document.activeElement);
                 var rowEl = inst.getRowElm(rowIndex);
+                var activeElement = document.activeElement;
+                //for selected options, activeElement needs to be the selected element
+                if(activeElement && activeElement.nodeName === "SELECT" && activeElement.options.length){
+                    activeElement = activeElement.options[activeElement.selectedIndex];
+                }
                 focusAfterSelector = {
                     rowIndex: rowIndex,
-                    selector: ux.selector.quickSelector(document.activeElement, rowEl[0], inst.options.gridFocusManager && inst.options.gridFocusManager.filterClasses || [])
+                    selector: ux.selector.quickSelector(activeElement, rowEl[0], inst.options.gridFocusManager && inst.options.gridFocusManager.filterClasses || [])
                 };
                 // drop the visible off selector if it exists.
                 focusAfterSelector.selector = focusAfterSelector.selector.replace(/:visible$/, "");


### PR DESCRIPTION
I'm toggling input boxes on the dataGrid and the activeElement is coming back as a list.  The datagrid-focusManager then throws an error because the "selector can only build a selection to a single DOMElement. A list was passed.".  This fix checks to see if the active element is a select input, then sets the activeElement as the selectedOption.