### PR TITLE
fixes package.json to better work with bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-    "name": "ux-angularjs-datagrid",
+    "name": "ux-datagrid",
     "version": "1.3.0",
     "filename": "datagrid",
     "packageName": "ux",
-    "main": "./build/latest/angular-ux-datagrid.js",
+    "main": "./build/latest/**/*.js",
     "dependencies": {},
     "repository": {
         "type": "git",


### PR DESCRIPTION
The package.json file does not work well with bower. 

Once the package is installed, using `bower install ux-datagrid`, which is the way the package is published in bower, it cannot be uninstalled using the same way `bower uninstall ux-datagrid`. Instead, it has to be uninstalled using `bower uninstall ux-angularjs-datagrid`. If it is inappropriate to rename the package in package.json, perhaps it should be published in the bower registry as `us-angularjs-datagrid`.

In addition, I believe the main section of the package.json file should be changed to a glob since the docs showing examples consuming plugins etc. from a sub-directory of latest. However, for those of us using build systems, which rely on referencing files using the main section of package.json, it makes it really hard to use the plugins. Alternatively, they could be broken out in their own repos.