### PR TITLE
Adding collapse of the index item to the closeAll method

### DIFF
--- a/src/addons/expandRows.js
+++ b/src/addons/expandRows.js
@@ -116,6 +116,7 @@ angular.module('ux').factory('expandRows', function () {
                 var intIndex = parseInt(index, 10);
                 if (!omitIndexes || (inst.rowsLength > intIndex && omitIndexes.indexOf(intIndex) === -1)) {
                     if (silent) {
+                        collapse(intIndex, true);
                         delete opened[index];
                     } else {
                         collapse(intIndex, immediate);


### PR DESCRIPTION
It appears that without first calling `collapse(specifiedIndex, true)` inside the `closeAll` method - that in some cases (specifically those where `silent === true`) the element and associated properties are not thoroughly cleaned-up/reverted. For example, if a css class had been added indicating it was in an open state, this class would not be removed. The item was only being removed from the `opened` hash. If a user action places this element back into view, it would be visible as it was (opened) despite not being in the `opened` hash object any longer. This was effectively making the closeAll method not truly close all opened items in some cases. This patch appears to address this.