### PR TITLE
windowScroll - fix for IE

### DIFF
--- a/src/addons/windowScroll.js
+++ b/src/addons/windowScroll.js
@@ -8,7 +8,7 @@ angular.module('ux').factory('windowScroll', function () {
             return window.screen.height;
         };
         result.onUpdateScroll = function onUpadateScroll(event) {
-            var val = window.scrollY;
+            var val = window.pageYOffset;
             if (inst.values.scroll !== val) {
                 inst.dispatch(ux.datagrid.events.ON_SCROLL_START, val);
                 inst.values.speed = val - inst.values.scroll;


### PR DESCRIPTION
In IE11 [`window.scrollY`](https://github.com/obogo/ux-angularjs-datagrid/blob/master/src/addons/windowScroll.js#L11) is not available and `undefined`. Thus will the datagrid compile from top to bottom instead of to compile the visible items on scroll.
[MDN](https://developer.mozilla.org/de/docs/Web/API/Window/scrollY) suggests to use `window.pageYOffset` for cross-browser compatibility.
It is reproducible with the windowScroll [sample](https://rawgit.com/obogo/ux-angularjs-datagrid/master/samples/window/index.html).